### PR TITLE
fix: include readme in copied project files

### DIFF
--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -117,7 +117,7 @@ pub async fn handle_project_upload(
             "--include=*/",
             "--include=Forc.toml",
             "--include=Forc.lock",
-            "--include=README.md",            
+            "--include=README.md",
             "--include=*.sw",
             "--exclude=*",
             "unpacked/",

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -117,6 +117,7 @@ pub async fn handle_project_upload(
             "--include=*/",
             "--include=Forc.toml",
             "--include=Forc.lock",
+            "--include=README.md",            
             "--include=*.sw",
             "--exclude=*",
             "unpacked/",


### PR DESCRIPTION
The readme was missing from copied project files so it was not getting populated in the DB.