### PR TITLE
fix: store github id since login can change

### DIFF
--- a/migrations/2025-04-01-000202_alter_users_add_github_id/down.sql
+++ b/migrations/2025-04-01-000202_alter_users_add_github_id/down.sql
@@ -1,0 +1,20 @@
+-- Remove `github_id` column from the `users` table
+ALTER TABLE users
+DROP COLUMN github_id;
+
+-- Restore unique constraint on github_login
+ALTER TABLE users
+ADD CONSTRAINT users_github_login_key UNIQUE (github_login);
+
+-- Restore original foreign keys without cascade delete
+ALTER TABLE sessions
+DROP CONSTRAINT sessions_user_id_fkey,
+ADD CONSTRAINT sessions_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES users(id);
+
+ALTER TABLE api_tokens
+DROP CONSTRAINT api_tokens_user_id_fkey,
+ADD CONSTRAINT api_tokens_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES users(id);

--- a/migrations/2025-04-01-000202_alter_users_add_github_id/up.sql
+++ b/migrations/2025-04-01-000202_alter_users_add_github_id/up.sql
@@ -1,0 +1,58 @@
+-- Update sessions foreign key to cascade deletes
+ALTER TABLE sessions
+DROP CONSTRAINT sessions_user_id_fkey,
+ADD CONSTRAINT sessions_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES users(id)
+    ON DELETE CASCADE;
+
+-- Update api_tokens foreign key to cascade deletes
+ALTER TABLE api_tokens
+DROP CONSTRAINT api_tokens_user_id_fkey,
+ADD CONSTRAINT api_tokens_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES users(id)
+    ON DELETE CASCADE;
+
+-- Update packages foreign key to cascade deletes
+ALTER TABLE packages
+DROP CONSTRAINT packages_user_owner_fkey,
+ADD CONSTRAINT packages_user_owner_fkey
+    FOREIGN KEY (user_owner)
+    REFERENCES users(id)
+    ON DELETE CASCADE;
+
+-- Update package_versions foreign key to cascade deletes
+ALTER TABLE package_versions
+DROP CONSTRAINT package_versions_published_by_fkey,
+ADD CONSTRAINT package_versions_published_by_fkey
+    FOREIGN KEY (published_by)
+    REFERENCES users(id)
+    ON DELETE CASCADE;
+
+-- Delete all existing users since we can't assign them valid github_ids
+DELETE FROM users;
+
+-- Drop unique constraint from github_login
+ALTER TABLE users
+DROP CONSTRAINT users_github_login_key;
+
+-- Add `github_id` column to the `users` table
+ALTER TABLE users
+ADD COLUMN github_id BIGINT NOT NULL UNIQUE;
+
+-- Update package_versions foreign key to restrict deletes
+ALTER TABLE package_versions
+DROP CONSTRAINT package_versions_published_by_fkey,
+ADD CONSTRAINT package_versions_published_by_fkey
+    FOREIGN KEY (published_by)
+    REFERENCES users(id)
+    ON DELETE RESTRICT;
+
+-- Update packages foreign key to restrict deletes
+ALTER TABLE packages
+DROP CONSTRAINT packages_user_owner_fkey,
+ADD CONSTRAINT packages_user_owner_fkey
+    FOREIGN KEY (user_owner)
+    REFERENCES users(id)
+    ON DELETE RESTRICT;

--- a/migrations/2025-04-01-000202_alter_users_add_github_id/up.sql
+++ b/migrations/2025-04-01-000202_alter_users_add_github_id/up.sql
@@ -39,7 +39,7 @@ DROP CONSTRAINT users_github_login_key;
 
 -- Add `github_id` column to the `users` table
 ALTER TABLE users
-ADD COLUMN github_id BIGINT NOT NULL UNIQUE;
+ADD COLUMN github_id VARCHAR NOT NULL UNIQUE;
 
 -- Update package_versions foreign key to restrict deletes
 ALTER TABLE package_versions

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -6,7 +6,7 @@ use crate::models;
 #[serde(rename_all = "camelCase")]
 pub struct User {
     pub full_name: String,
-    pub github_id: i64,
+    pub github_id: String,
     pub email: Option<String>,
     pub avatar_url: Option<String>,
     pub github_url: String,

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -6,6 +6,7 @@ use crate::models;
 #[serde(rename_all = "camelCase")]
 pub struct User {
     pub full_name: String,
+    pub github_id: i64,
     pub email: Option<String>,
     pub avatar_url: Option<String>,
     pub github_url: String,
@@ -17,6 +18,7 @@ impl From<models::User> for User {
     fn from(user: models::User) -> Self {
         User {
             full_name: user.full_name,
+            github_id: user.github_id,
             email: user.email,
             avatar_url: user.avatar_url,
             github_url: user.github_url,

--- a/src/db/user_session.rs
+++ b/src/db/user_session.rs
@@ -18,6 +18,7 @@ impl DbConn {
         // Insert or update a user
         let new_user = models::NewUser {
             full_name: user.full_name.clone(),
+            github_id: user.github_id,
             github_login: user.github_login.clone(),
             github_url: user.github_url.clone(),
             avatar_url: user.avatar_url.clone(),
@@ -28,14 +29,17 @@ impl DbConn {
         let saved_user = diesel::insert_into(schema::users::table)
             .values(&new_user)
             .returning(models::User::as_returning())
-            .on_conflict(schema::users::github_login)
+            .on_conflict(schema::users::github_id)
             .do_update()
             .set((
                 schema::users::full_name.eq(excluded(schema::users::full_name)),
                 schema::users::avatar_url.eq(excluded(schema::users::avatar_url)),
+                schema::users::email.eq(excluded(schema::users::email)),
+                schema::users::github_login.eq(excluded(schema::users::github_login)),
+                schema::users::github_url.eq(excluded(schema::users::github_url)),
             ))
             .get_result(self.inner())
-            .map_err(|err| DatabaseError::InsertUserFailed(user.github_login.clone(), err))?;
+            .map_err(|err| DatabaseError::InsertUserFailed(user.github_id.to_string(), err))?;
 
         let new_session = models::NewSession {
             user_id: saved_user.id,
@@ -47,7 +51,7 @@ impl DbConn {
             .values(&new_session)
             .returning(models::Session::as_returning())
             .get_result(self.inner())
-            .map_err(|err| DatabaseError::InsertSessionFailed(user.github_login.clone(), err))?;
+            .map_err(|err| DatabaseError::InsertSessionFailed(user.github_id.to_string(), err))?;
 
         Ok(saved_session)
     }

--- a/src/db/user_session.rs
+++ b/src/db/user_session.rs
@@ -18,7 +18,7 @@ impl DbConn {
         // Insert or update a user
         let new_user = models::NewUser {
             full_name: user.full_name.clone(),
-            github_id: user.github_id,
+            github_id: user.github_id.clone(),
             github_login: user.github_login.clone(),
             github_url: user.github_url.clone(),
             avatar_url: user.avatar_url.clone(),

--- a/src/github.rs
+++ b/src/github.rs
@@ -14,7 +14,7 @@ struct GithubOauthResponse {
 #[derive(Deserialize, Debug)]
 struct GithubUserResponse {
     pub name: Option<String>,
-    pub id: i64,
+    pub id: String,
     pub email: Option<String>,
     pub avatar_url: Option<String>,
     pub html_url: String,

--- a/src/github.rs
+++ b/src/github.rs
@@ -13,7 +13,8 @@ struct GithubOauthResponse {
 
 #[derive(Deserialize, Debug)]
 struct GithubUserResponse {
-    pub name: String,
+    pub name: Option<String>,
+    pub id: i64,
     pub email: Option<String>,
     pub avatar_url: Option<String>,
     pub html_url: String,
@@ -89,7 +90,8 @@ async fn fetch_user(token: String) -> Result<User, GithubError> {
         })?;
 
     let user = User {
-        full_name: body.name,
+        full_name: body.name.unwrap_or(body.login.clone()),
+        github_id: body.id,
         email: body.email,
         avatar_url: body.avatar_url,
         github_url: body.html_url,

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct User {
     pub id: Uuid,
-    pub github_id: i64,
+    pub github_id: String,
     pub full_name: String,
     pub github_login: String,
     pub github_url: String,
@@ -25,7 +25,7 @@ pub struct User {
 #[diesel(table_name = crate::schema::users)]
 pub struct NewUser {
     pub full_name: String,
-    pub github_id: i64,
+    pub github_id: String,
     pub github_login: String,
     pub github_url: String,
     pub avatar_url: Option<String>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct User {
     pub id: Uuid,
+    pub github_id: i64,
     pub full_name: String,
     pub github_login: String,
     pub github_url: String,
@@ -24,6 +25,7 @@ pub struct User {
 #[diesel(table_name = crate::schema::users)]
 pub struct NewUser {
     pub full_name: String,
+    pub github_id: i64,
     pub github_login: String,
     pub github_url: String,
     pub avatar_url: Option<String>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -99,7 +99,7 @@ diesel::table! {
         email -> Nullable<Varchar>,
         is_admin -> Bool,
         created_at -> Timestamptz,
-        github_id -> Int8,
+        github_id -> Varchar,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -99,6 +99,7 @@ diesel::table! {
         email -> Nullable<Varchar>,
         is_admin -> Bool,
         created_at -> Timestamptz,
+        github_id -> Int8,
     }
 }
 

--- a/tests/db_integration.rs
+++ b/tests/db_integration.rs
@@ -15,7 +15,7 @@ use serial_test::serial;
 use url::Url;
 
 // Test constants
-const TEST_GITHUB_ID_1: i64 = 1;
+const TEST_GITHUB_ID_1: &str = "1";
 const TEST_LOGIN_1: &str = "AliceBobbins";
 const TEST_FULL_NAME_1: &str = "Alice Bobbins";
 const TEST_EMAIL_1: &str = "alice@bob.com";
@@ -64,7 +64,7 @@ fn clear_tables(db: &mut DbConn) {
 fn mock_user_1() -> api::auth::User {
     api::auth::User {
         github_login: TEST_LOGIN_1.to_string(),
-        github_id: TEST_GITHUB_ID_1,
+        github_id: TEST_GITHUB_ID_1.to_string(),
         full_name: TEST_FULL_NAME_1.to_string(),
         email: Some(TEST_EMAIL_1.to_string()),
         avatar_url: Some(TEST_URL_1.to_string()),

--- a/tests/db_integration.rs
+++ b/tests/db_integration.rs
@@ -15,6 +15,7 @@ use serial_test::serial;
 use url::Url;
 
 // Test constants
+const TEST_GITHUB_ID_1: i64 = 1;
 const TEST_LOGIN_1: &str = "AliceBobbins";
 const TEST_FULL_NAME_1: &str = "Alice Bobbins";
 const TEST_EMAIL_1: &str = "alice@bob.com";
@@ -63,6 +64,7 @@ fn clear_tables(db: &mut DbConn) {
 fn mock_user_1() -> api::auth::User {
     api::auth::User {
         github_login: TEST_LOGIN_1.to_string(),
+        github_id: TEST_GITHUB_ID_1,
         full_name: TEST_FULL_NAME_1.to_string(),
         email: Some(TEST_EMAIL_1.to_string()),
         avatar_url: Some(TEST_URL_1.to_string()),


### PR DESCRIPTION
- stores the github ID as a unique value in the `users` table, and updates the login (handle) if it changes.
- fixes a bug where user response wasn't deseralized when `name` was null. Defaults to using the login as the name when name is null.

The up-migration does the following:
- alter the foreign key contraints in other tables to allow users to be deleted
- deletes all users (since they don't have github_ids store)
- adds the github_id column
- restores the foreign key constraints to what they were