### PR TITLE
chore: upgrade to rust 1.85.0

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.84.0
+  RUST_VERSION: 1.85.0
 
 jobs:
   cancel-previous-runs:

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -29,7 +29,7 @@ COPY . .
 RUN cargo build
 
 # Stage 2: Run
-FROM rust:1.84 as run
+FROM rust:1.85 as run
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends ca-certificates curl git libpq5 rsync \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 profile = "default" # include rustfmt, clippy

--- a/src/middleware/token_auth.rs
+++ b/src/middleware/token_auth.rs
@@ -53,9 +53,9 @@ impl<'r> FromRequest<'r> for TokenAuth {
 
         match db.transaction(|conn| {
             if let Ok(token) = conn.get_token(PlainToken::from(token.to_string())) {
-                if token.expires_at.map_or(true, |expires_at| {
-                    expires_at > DateTime::<Utc>::from(SystemTime::now())
-                }) {
+                 if token.expires_at.is_none_or(|expires_at| {
+                     expires_at > DateTime::<Utc>::from(SystemTime::now())
+                 }) {
                     Ok(TokenAuth { token })
                 } else {
                     Err(TokenAuthError::Expired)

--- a/src/middleware/token_auth.rs
+++ b/src/middleware/token_auth.rs
@@ -53,9 +53,10 @@ impl<'r> FromRequest<'r> for TokenAuth {
 
         match db.transaction(|conn| {
             if let Ok(token) = conn.get_token(PlainToken::from(token.to_string())) {
-                 if token.expires_at.is_none_or(|expires_at| {
-                     expires_at > DateTime::<Utc>::from(SystemTime::now())
-                 }) {
+                if token
+                    .expires_at
+                    .is_none_or(|expires_at| expires_at > DateTime::<Utc>::from(SystemTime::now()))
+                {
                     Ok(TokenAuth { token })
                 } else {
                     Err(TokenAuthError::Expired)


### PR DESCRIPTION
The newest version of `fuels` requires this to install from source.