### PR TITLE
fix: Add github known hosts to docker image

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -32,12 +32,17 @@ RUN cargo build
 FROM rust:1.85 as run
 
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends ca-certificates curl git libpq5 rsync \
+    && apt-get install -y --no-install-recommends ca-certificates curl jq git libpq5 rsync \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Add GitHub SSH keys to known_hosts
+RUN mkdir -p /root/.ssh && \
+    curl --silent https://api.github.com/meta \
+    | jq --raw-output '"github.com "+.ssh_keys[]' >> ~/.ssh/known_hosts
+    
 # Install the latest 20 versions of forc with cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 RUN tags=$(curl -s "https://api.github.com/repos/FuelLabs/sway/tags?per_page=20" | grep '"name"' | sed -E 's/.*"name": "v?([^"]+)".*/\1/') && \


### PR DESCRIPTION
This PR fixes this error that occurs when the server tries to clone the `forc.pub-index` repo from github:

```
 error: Publish error: Repository error: Failed to clone repository: invalid or unknown remote ssh hostkey; class=Ssh (23); code=Certificate (-17)
```

Adding github's ssh keys to known_hosts fixes the issue. I was verified this locally.