### PR TITLE
chore: additional logging in upload API

### DIFF
--- a/src/file_uploader/mod.rs
+++ b/src/file_uploader/mod.rs
@@ -20,6 +20,7 @@ impl<'a, T: PinataClient, E: S3Client> FileUploader<'a, T, E> {
     }
 
     pub async fn upload_file(&self, path: &Path) -> Result<String, UploadError> {
+        tracing::info!("Uploading file to IPFS: {:?}", path);
         let ipfs_hash = self.pinata_client.upload_file_to_ipfs(path).await?;
 
         // Read file contents
@@ -29,6 +30,7 @@ impl<'a, T: PinataClient, E: S3Client> FileUploader<'a, T, E> {
             .map_err(|_| UploadError::ReadFile)?;
 
         // Upload to S3
+        tracing::info!("Uploading file to S3: {:?}", path);
         self.s3_client
             .upload_file_to_s3(path, ipfs_hash.clone())
             .await?;

--- a/src/file_uploader/s3.rs
+++ b/src/file_uploader/s3.rs
@@ -67,7 +67,7 @@ impl S3Client for S3ClientImpl {
                 .body(ByteStream::from(buffer))
                 .send()
                 .await
-                .map_err(|e| UploadError::S3UploadFailed(format!("{:?}", e)))?;
+                .map_err(|e| UploadError::S3UploadFailed(e.to_string()))?;
         }
         Ok(())
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use semver::Version;
-use std::path::Path;
+use std::{env, path::Path};
 
 pub fn validate_or_format_semver(version: &str) -> Option<String> {
     // Remove the leading 'v' if it exists
@@ -23,7 +23,12 @@ pub fn load_env() {
 
     // Then load `.env.local`, potentially overwriting values from `.env`
     if let Err(e) = dotenvy::from_path_override(Path::new(".env.local")) {
-        tracing::error!("Could not load .env.local: {}", e);
+        if env::var("RUN_ENV").unwrap_or_default() == "local" {
+            // If RUN_ENV is not set, log the error
+            tracing::error!("Could not load .env.local: {}", e);
+        }
+
+        tracing::info!("Could not load .env.local: {}", e);
     }
 }
 


### PR DESCRIPTION
Adds additional logs to the upload API and cleans up the error handling by adding a default catcher that also logs errors caught by the rocker server and returns the error code as a string. Also silences a noisy log that only applies when running locally.