### PR TITLE
Json logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ forc-pkg = "0.68"
 git2 = "0.19.0"
 aws-sdk-s3 = "1.77"
 aws-config = "1.5.17"
+
+[profile.release]
+panic = "unwind"

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -26,7 +26,7 @@ RUN cargo chef cook --recipe-path recipe.json
 # Up to this point, if our dependency tree stays the same,
 # all layers should be cached.
 COPY . .
-RUN cargo build
+RUN cargo build --release
 
 # Stage 2: Run
 FROM rust:1.85 as run
@@ -54,8 +54,7 @@ RUN tags=$(curl -s "https://api.github.com/repos/FuelLabs/sway/tags?per_page=20"
 
 WORKDIR /root/
 
-COPY --from=builder /build/target/debug/forc_pub .
-COPY --from=builder /build/target/debug/forc_pub.d .
+COPY --from=builder /build/target/release/forc_pub .
 COPY --from=builder /build/Rocket.toml .
 COPY --from=builder /build/.env .
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,6 @@ fn health() -> String {
 // Launch the rocket server.
 #[launch]
 async fn rocket() -> _ {
-
     setup_tracing_subscriber();
 
     let s3_client = S3ClientImpl::new().await.expect("s3 client");
@@ -305,14 +304,12 @@ async fn rocket() -> _ {
 
 fn setup_tracing_subscriber() {
     let default_filter = "info"; // Default log level if RUST_LOG is not set
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(default_filter));
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));
     // Initialize the tracing subscriber with JSON format and no ANSI colors for non-local.
     // For local, use standard formatting. Both respect RUST_LOG.
     if env::var("RUN_ENV").unwrap_or_default() == "local" {
-        tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
-            .init();
+        tracing_subscriber::fmt().with_env_filter(env_filter).init();
     } else {
         tracing_subscriber::fmt()
             .json()

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,6 +268,8 @@ fn health() -> String {
 #[launch]
 async fn rocket() -> _ {
     tracing_subscriber::fmt()
+        .json()
+        .with_ansi(false)
         .with_max_level(LevelFilter::INFO)
         .init();
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,8 +27,6 @@ pub fn load_env() {
             // If RUN_ENV is not set, log the error
             tracing::error!("Could not load .env.local: {}", e);
         }
-
-        tracing::info!("Could not load .env.local: {}", e);
     }
 }
 


### PR DESCRIPTION
Use Json for logs to make tracing properly indexed into elastic search / oodle. Also disable ansi colors to strip all the odd color coding characters that obscure the logs in systems that dont support rendering ansi colors in text (ie. web based log viewers).