### PR TITLE
feat: use SSE for long-running uploads

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -51,7 +51,7 @@ RUN tags=$(curl -s "https://api.github.com/repos/FuelLabs/sway/tags?per_page=20"
     echo "Tags fetched from the repository:" && \
     for tag in $tags; do \
     echo "Tag: $tag" && \
-    cargo binstall --no-confirm --root "forc-$tag" --pkg-url="https://github.com/FuelLabs/sway/releases/download/v$tag/forc-binaries-linux_arm64.tar.gz" --bin-dir="forc-binaries/forc" --pkg-fmt="tgz" forc; \
+    cargo binstall --no-confirm --root "forc-$tag" --pkg-url="https://github.com/FuelLabs/sway/releases/download/v$tag/forc-binaries-linux_amd64.tar.gz" --bin-dir="forc-binaries/forc" --pkg-fmt="tgz" forc; \
     done
 
 COPY --from=builder /build/target/release/forc_pub .

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update -y \
 RUN mkdir -p /root/.ssh && \
     curl --silent https://api.github.com/meta \
     | jq --raw-output '"github.com "+.ssh_keys[]' >> ~/.ssh/known_hosts
+    
+WORKDIR /root/
 
 # Install the latest 20 versions of forc with cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
@@ -51,8 +53,6 @@ RUN tags=$(curl -s "https://api.github.com/repos/FuelLabs/sway/tags?per_page=20"
     echo "Tag: $tag" && \
     cargo binstall --no-confirm --root "forc-$tag" --pkg-url="https://github.com/FuelLabs/sway/releases/download/v$tag/forc-binaries-linux_arm64.tar.gz" --bin-dir="forc-binaries/forc" --pkg-fmt="tgz" forc; \
     done
-
-WORKDIR /root/
 
 COPY --from=builder /build/target/release/forc_pub .
 COPY --from=builder /build/Rocket.toml .

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,7 +25,7 @@ pub struct EmptyResponse;
 #[derive(Error, Debug, Serialize)]
 pub enum ApiError {
     #[error("Error: {0}")]
-    Generic(String),
+    Generic(String, Status),
 
     #[error("Database error: {0}")]
     #[serde(skip)]
@@ -46,7 +46,7 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for ApiError {
     fn respond_to(self, _request: &'r Request<'_>) -> rocket::response::Result<'o> {
         error!("API error: {}", self);
         let (status, message) = match self {
-            ApiError::Generic(ref err) => (Status::InternalServerError, err.to_string()),
+            ApiError::Generic(ref err, ref status) => (*status, err.to_string()),
             ApiError::Database(ref err) => (
                 Status::InternalServerError,
                 format!("Database error: {}", err),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,12 +22,17 @@ pub type ApiResult<T> = Result<Json<T>, ApiError>;
 #[derive(Serialize)]
 pub struct EmptyResponse;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize)]
 pub enum ApiError {
+    #[error("Error: {0}")]
+    Generic(String),
+
     #[error("Database error: {0}")]
+    #[serde(skip)]
     Database(#[from] crate::db::error::DatabaseError),
 
     #[error("GitHub error: {0}")]
+    #[serde(skip)]
     Github(#[from] crate::github::GithubError),
 
     #[error("Upload error: {0}")]
@@ -41,6 +46,7 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for ApiError {
     fn respond_to(self, _request: &'r Request<'_>) -> rocket::response::Result<'o> {
         error!("API error: {}", self);
         let (status, message) = match self {
+            ApiError::Generic(ref err) => (Status::InternalServerError, err.to_string()),
             ApiError::Database(ref err) => (
                 Status::InternalServerError,
                 format!("Database error: {}", err),

--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DatabaseError {
-    #[error("Transaction failed: {0}")]
+    #[error("Transaction failed")]
     TransactionFailed(#[from] diesel::result::Error),
 
     #[error("Invalid UUID: {0}")]

--- a/src/handlers/publish.rs
+++ b/src/handlers/publish.rs
@@ -15,6 +15,7 @@ use forc_pkg::source::reg::{
 };
 use forc_pkg::PackageManifest;
 use semver::Version;
+use serde::Serialize;
 use tempfile::TempDir;
 use thiserror::Error;
 use tracing::error;
@@ -22,15 +23,17 @@ use tracing::info;
 use url::Url;
 use uuid::Uuid;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize)]
 pub enum PublishError {
     #[error("Invalid Forc manifest: {0}")]
     InvalidForcManifest(String),
 
     #[error(transparent)]
+    #[serde(skip)]
     Database(#[from] DatabaseError),
 
     #[error(transparent)]
+    #[serde(skip)]
     Diesel(#[from] diesel::result::Error),
 
     #[error(transparent)]

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -6,6 +6,7 @@ use flate2::{
     {read::GzDecoder, write::GzEncoder},
 };
 use forc_util::bytecode::get_bytecode_id;
+use serde::Serialize;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -22,7 +23,7 @@ const FORC_MANIFEST_FILE: &str = "Forc.toml";
 const MAX_UPLOAD_SIZE_STR: &str = "10MB";
 pub const TARBALL_NAME: &str = "project.tgz";
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq, Serialize)]
 pub enum UploadError {
     #[error("Failed to create temporary directory.")]
     CreateTempDir,

--- a/src/index/handler/mod.rs
+++ b/src/index/handler/mod.rs
@@ -2,9 +2,10 @@ pub mod git;
 
 use async_trait::async_trait;
 use forc_pkg::source::reg::index_file::PackageEntry;
+use serde::Serialize;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize)]
 pub enum IndexPublishError {
     #[error("Connection lost with the publishing backend: {0}")]
     ConnectionLost(String),
@@ -25,9 +26,11 @@ pub enum IndexPublishError {
     PushError(String),
 
     #[error("Failed to parse index file: {0}")]
+    #[serde(skip)]
     ParseError(#[from] serde_json::Error),
 
     #[error("Package index file error: {0}")]
+    #[serde(skip)]
     FileSystemError(#[from] std::io::Error),
 
     #[error("No changes to commit")]
@@ -37,6 +40,7 @@ pub enum IndexPublishError {
     PackageDataError(String),
 
     #[error("Git relatated error: {0}")]
+    #[serde(skip)]
     Git2Error(#[from] git2::Error),
 
     #[error("Repository error: {0}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,10 @@ fn default_catcher(status: Status, _req: &Request<'_>) -> response::status::Cust
     );
     response::status::Custom(
         status,
-        ApiError::Generic(format!("{} - {}", status.code, status.reason_lossy())),
+        ApiError::Generic(
+            format!("{} - {}", status.code, status.reason_lossy()),
+            status,
+        ),
     )
 }
 


### PR DESCRIPTION
Related https://github.com/FuelLabs/sway/pull/7178

This pull request introduces several changes to improve error handling, enhance serialization support, and implement streaming responses for the `upload_project` endpoint. The most significant update is changing the `upload_project` function to use `EventStream` for real-time feedback during uploads. This allows the server to send keep-alives to the client to prevent the connection being dropped for long-running requests, which can happen when the server has to install a version of forc. 

Another benefit of using SSE is that we can also send status updates that the CLI can show to the user so they don't have to wonder what is taking so long.

### Error Handling and Serialization Improvements:
* Added `Serialize` to various error enums (`ApiError`, `PublishError`, `UploadError`, and `IndexPublishError`) to support structured error responses. Additionally, used `#[serde(skip)]` to exclude certain fields from serialization when necessary. [[1]](diffhunk://#diff-4715d1ca31922b72b1d5c42d64759dfa3e247bf3fb4a9066d1c4711e6f8478f5L25-R35) [[2]](diffhunk://#diff-70f55aa27c830db76adfea5759054f845d1bc4e6a4a1e1acac93f4f486451dbaR18-R36) [[3]](diffhunk://#diff-da4dc163aa632a91c2a53dfd6534d6a1bdf7efbb401a525bae347e77b23e650cL25-R26) [[4]](diffhunk://#diff-0dda450de13c089ff4a2f331ac3c81c7d7052ba3e72ed1ba1d4a386cec61b0d3R5-R8) [[5]](diffhunk://#diff-0dda450de13c089ff4a2f331ac3c81c7d7052ba3e72ed1ba1d4a386cec61b0d3R29-R33) [[6]](diffhunk://#diff-0dda450de13c089ff4a2f331ac3c81c7d7052ba3e72ed1ba1d4a386cec61b0d3R43)
* Updated the default error catcher to return `ApiError::Generic` with structured error details instead of plain strings.

### Streaming Response for `upload_project` Endpoint:
* Refactored the `upload_project` function to use `EventStream` for real-time updates during project uploads. This includes emitting progress events such as "Uploading sway project" and "Validating forc version," as well as structured error events for failures.

### Utility and Dependency Updates:
* Added `load_env` to initialize environment variables and included new dependencies like `rocket::tokio::time` and `rocket::tokio::task` for asynchronous operations. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL29-R37) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR49) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR373)

These changes collectively enhance the robustness of the API by improving error handling, providing better feedback to users during uploads, and ensuring compatibility with structured serialization formats.