### PR TITLE
chore: bump forc-pkg to 0.68.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,9 +2175,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "forc-pkg"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e22a3260bbd632dbb046e955d082003f967b47ef690a2bbb6c7075a56b2b7ad"
+checksum = "c36d7bb0e2ad7c1f005e73eaab91b07584dffa9703b329a731d438d57b0f1e68"
 dependencies = [
  "ansiterm",
  "anyhow",
@@ -2208,6 +2208,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "toml 0.8.20",
+ "toml_edit",
  "tracing",
  "url",
  "vec1",
@@ -2216,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "forc-tracing"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0959efc18cb7fe28a4461c9e09357e839de2a4994726307e54748e71d575c1c"
+checksum = "c2e9f5a7daa7a5bf07a79de9f1eb4d9d3814f68c57afbcf560e8aebcc424cb39"
 dependencies = [
  "ansiterm",
  "regex",
@@ -2228,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d036fc10185a6fb939133f8b747a9f8b9e96000bd30519f5974c69a29a65594"
+checksum = "6da7284b1a6e83c4b7dfcced60cbce90d3cbc33d12e38d671e2e19e337a4fd60"
 dependencies = [
  "annotate-snippets",
  "ansiterm",
@@ -2241,12 +2242,10 @@ dependencies = [
  "forc-tracing",
  "fuel-asm",
  "hex",
- "mark-flaky-tests",
  "paste",
  "regex",
  "serde",
  "serde_json",
- "serial_test",
  "sha2",
  "sway-core",
  "sway-error",
@@ -2326,9 +2325,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuel-abi-types"
-version = "0.8.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026deca571c0d3304a4392a0d99c7477d58cade18b2861232c151eb0816dde0a"
+checksum = "94916fee0e005fe1b9581c12edb7ad9b02c5b121b939716438d69ffcdd45e855"
 dependencies = [
  "itertools 0.10.5",
  "lazy_static",
@@ -3683,28 +3682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "mark-flaky-tests"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586c4a7c95a05351b04ebbe4f60edc53c3bb611651b1bf0be54a9575a95b4930"
-dependencies = [
- "mark-flaky-tests-macro",
-]
-
-[[package]]
-name = "mark-flaky-tests-macro"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078b1ffd16b299642ebc515a520c3793f6fe0db38c2e6a2abf686db22e58ab84"
-dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -5781,9 +5758,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sway-ast"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18e21d34b19107c214b2dcc4d4ebc2cc69f65904f18e639f7dbd49f57ac3a42"
+checksum = "4935c9f24cdf846314ae82021cb22cb44ce7445c69db87bc9a26810dd755e4c9"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -5795,9 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1528ed64b406e2ab9d86e4a01305ad01f0a363488f8221abf84aa21e75714b71"
+checksum = "ad20159252f4d9f8f4fe72a0796cbf0b64924824d9312da68a7f64df7fb99322"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -5842,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "sway-error"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5770b4f23d9fc7966b3997f70b9b10a2cbb2ac13f557910e1061632c838bfc4"
+checksum = "26c13f00ff24e407f31b1ebcb5edb1eaadcdaf16baabd1e3b6918b51c11c7ecc"
 dependencies = [
  "either",
  "in_definite",
@@ -5857,9 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "sway-features"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff25e5818a6023dfc847f99e56cefa76bc9cf5de92fe99dfce560cdcfcb571c"
+checksum = "28bdbf5cab2fd33cb3f64ea16a1404dae82fd0de30d80d26741c3f125a85eeb3"
 dependencies = [
  "clap",
  "paste",
@@ -5869,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37c12ba0722073b650aff53441396fa965170f70fda873c332279b0c40b4297"
+checksum = "22d3a161aca62c7baa5c4ace4c340dcb64e210c2b7cbfdd3e9d656a5c9147bb6"
 dependencies = [
  "anyhow",
  "downcast-rs",
@@ -5892,9 +5869,9 @@ dependencies = [
 
 [[package]]
 name = "sway-ir-macros"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143c717794908a7974bd5c91bedefaa24a81bd7dd3a2d2bc8eb60612fc7d9b1a"
+checksum = "21f468b9133ab36d4b47ca52f83b2d6df7feb8eeb6fe56bab9df24d4c7f56d9d"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -5904,9 +5881,9 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e53786b49531cd77f45e8340459054846e436cdf60fee58824fc5530c6d619e"
+checksum = "08818e541221128599e1173162346a8e5745474a9213502ea5171484d427e740"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -5923,9 +5900,9 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5df9e7f0b2656e83d137b0e3ccc74ff9b24ec717969391b14524435507d9f0"
+checksum = "6631beb69435da9986f65f8e37a7572d809f853aca91df648b59631d8beb7028"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -5939,13 +5916,14 @@ dependencies = [
  "serde",
  "sway-utils",
  "thiserror 1.0.69",
+ "toml 0.8.20",
 ]
 
 [[package]]
 name = "sway-utils"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200d0c01d200d01afc47e82bff05c3398034f00a075d54dafa2d471d28702eac"
+checksum = "95137f18d9f93146428395ee71eae2dbd35cc85aca892ef6d1d553e73fdb5584"
 dependencies = [
  "serde",
  "walkdir",
@@ -5953,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "swayfmt"
-version = "0.68.3"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c709cf6990e17fb7420f76eb3dd4930551737cd7f84012c293eacb87b4ab6a"
+checksum = "2b4f71c9e721491bb70d6336e399f37007497e9be4fd8f2a9514e6f51259a19b"
 dependencies = [
  "anyhow",
  "forc-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ chrono = { version = "0.4", features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
 forc-util = "0.68"
 async-trait = "0.1.88"
-forc-pkg = "0.68"
+forc-pkg = "0.68.7"
 git2 = "0.19.0"
 aws-sdk-s3 = "1.77"
 aws-config = "1.5.17"


### PR DESCRIPTION
Bumps forc-pkg to 0.68.7 to get implicit-std packages working correctly.