### PR TITLE
feat: extend endpoint to optionally inline abi

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -26,6 +26,10 @@ pub struct FullPackage {
     pub source_code_ipfs_url: String,
     pub abi_ipfs_url: Option<String>,
 
+    // Inline ABI data (only populated when requested)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub abi: Option<serde_json::Value>,
+
     // Version Metadata
     pub repository: Option<Url>,
     pub documentation: Option<Url>,
@@ -55,6 +59,7 @@ impl From<crate::models::FullPackage> for FullPackage {
             abi_ipfs_url: full_package
                 .abi_ipfs_hash
                 .map(|hash| ipfs_hash_to_abi_url(&hash)),
+            abi: None, // Will be populated when inline_abi is requested
             repository: full_package.repository.and_then(string_to_url),
             documentation: full_package.documentation.and_then(string_to_url),
             homepage: full_package.homepage.and_then(string_to_url),

--- a/src/file_uploader/mod.rs
+++ b/src/file_uploader/mod.rs
@@ -81,7 +81,9 @@ pub(crate) mod tests {
                 Err(UploadError::IpfsUploadFailed("IPFS error".to_string()))
             }
             async fn fetch_ipfs_content(&self, _ipfs_hash: &str) -> Result<Vec<u8>, UploadError> {
-                Err(UploadError::IpfsUploadFailed("IPFS fetch error".to_string()))
+                Err(UploadError::IpfsUploadFailed(
+                    "IPFS fetch error".to_string(),
+                ))
             }
         }
 

--- a/src/file_uploader/mod.rs
+++ b/src/file_uploader/mod.rs
@@ -80,6 +80,9 @@ pub(crate) mod tests {
             async fn upload_file_to_ipfs(&self, _path: &Path) -> Result<String, UploadError> {
                 Err(UploadError::IpfsUploadFailed("IPFS error".to_string()))
             }
+            async fn fetch_ipfs_content(&self, _ipfs_hash: &str) -> Result<Vec<u8>, UploadError> {
+                Err(UploadError::IpfsUploadFailed("IPFS fetch error".to_string()))
+            }
         }
 
         let pinata_client = FailingPinataClient;

--- a/src/file_uploader/pinata.rs
+++ b/src/file_uploader/pinata.rs
@@ -58,11 +58,11 @@ impl PinataClient for PinataClientImpl {
         let url = format!("{pinata_domain}/ipfs/{ipfs_hash}");
 
         let response = reqwest::get(&url).await.map_err(|e| {
-            UploadError::IpfsUploadFailed(format!("Failed to fetch from IPFS: {}", e))
+            UploadError::IpfsFetchFailed(format!("Failed to fetch from IPFS: {}", e))
         })?;
 
         if !response.status().is_success() {
-            return Err(UploadError::IpfsUploadFailed(format!(
+            return Err(UploadError::IpfsFetchFailed(format!(
                 "IPFS fetch failed with status: {}",
                 response.status()
             )));
@@ -73,7 +73,7 @@ impl PinataClient for PinataClientImpl {
             .await
             .map(|bytes| bytes.to_vec())
             .map_err(|e| {
-                UploadError::IpfsUploadFailed(format!("Failed to read IPFS content: {}", e))
+                UploadError::IpfsFetchFailed(format!("Failed to read IPFS content: {}", e))
             })
     }
 }

--- a/src/file_uploader/pinata.rs
+++ b/src/file_uploader/pinata.rs
@@ -56,23 +56,25 @@ impl PinataClient for PinataClientImpl {
     async fn fetch_ipfs_content(&self, ipfs_hash: &str) -> Result<Vec<u8>, UploadError> {
         let pinata_domain = env::var("PINATA_URL").expect("PINATA_URL must be set");
         let url = format!("{pinata_domain}/ipfs/{ipfs_hash}");
-        
-        let response = reqwest::get(&url)
-            .await
-            .map_err(|e| UploadError::IpfsUploadFailed(format!("Failed to fetch from IPFS: {}", e)))?;
-        
+
+        let response = reqwest::get(&url).await.map_err(|e| {
+            UploadError::IpfsUploadFailed(format!("Failed to fetch from IPFS: {}", e))
+        })?;
+
         if !response.status().is_success() {
             return Err(UploadError::IpfsUploadFailed(format!(
                 "IPFS fetch failed with status: {}",
                 response.status()
             )));
         }
-        
+
         response
             .bytes()
             .await
             .map(|bytes| bytes.to_vec())
-            .map_err(|e| UploadError::IpfsUploadFailed(format!("Failed to read IPFS content: {}", e)))
+            .map_err(|e| {
+                UploadError::IpfsUploadFailed(format!("Failed to read IPFS content: {}", e))
+            })
     }
 }
 

--- a/src/handlers/upload.rs
+++ b/src/handlers/upload.rs
@@ -75,6 +75,9 @@ pub enum UploadError {
 
     #[error("Upload does not contain a Forc manifest.")]
     MissingForcManifest,
+
+    #[error("Failed to fetch from IPFS. Err: {0}")]
+    IpfsFetchFailed(String),
 }
 
 /// Handles the project upload process by:

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,8 @@ async fn package(
         if let Some(abi_hash) = db_data.abi_ipfs_hash {
             match pinata_client.fetch_ipfs_content(&abi_hash).await {
                 Ok(abi_content) => {
-                    if let Ok(abi_json) = serde_json::from_slice::<serde_json::Value>(&abi_content) {
+                    if let Ok(abi_json) = serde_json::from_slice::<serde_json::Value>(&abi_content)
+                    {
                         full_package.abi = Some(abi_json);
                     }
                 }

--- a/tests/db_integration.rs
+++ b/tests/db_integration.rs
@@ -421,3 +421,204 @@ fn test_package_categories_keywords() {
         Ok::<(), diesel::result::Error>(())
     });
 }
+
+// Tests for ABI inlining functionality
+#[tokio::test]
+#[serial]
+async fn test_abi_inlining_with_mock_pinata() {
+    use forc_pub::file_uploader::pinata::PinataClient;
+    use forc_pub::handlers::upload::UploadError;
+    use forc_pub::models;
+    use forc_pub::api::search::FullPackage;
+    use std::path::Path;
+    use std::env;
+    // Create a test mock client that returns mock ABI content
+    struct TestMockPinataClient;
+    
+    impl PinataClient for TestMockPinataClient {
+        async fn new() -> Result<Self, UploadError> {
+            Ok(TestMockPinataClient)
+        }
+        
+        async fn upload_file_to_ipfs(&self, _path: &Path) -> Result<String, UploadError> {
+            Ok("test_abi_hash".to_string())
+        }
+        
+        async fn fetch_ipfs_content(&self, _ipfs_hash: &str) -> Result<Vec<u8>, UploadError> {
+            // Return a more realistic ABI structure
+            Ok(r#"{"types": [{"id": 1, "type": "u64"}], "functions": [{"name": "test_function", "inputs": [], "outputs": []}]}"#.as_bytes().to_vec())
+        }
+    }
+    
+    // Set up environment variables
+    env::set_var("PINATA_URL", "https://test-pinata.com");
+    
+    // Create a mock FullPackage from database model (simulating what we'd get from DB)
+    let db_full_package = models::FullPackage {
+        name: "test-abi-package".to_string(),
+        version: "1.0.0".to_string(),
+        description: Some("Test package with ABI".to_string()),
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        bytecode_identifier: None,
+        forc_version: "0.68.0".to_string(),
+        source_code_ipfs_hash: "source_hash_123".to_string(),
+        abi_ipfs_hash: Some("abi_hash_456".to_string()),
+        repository: None,
+        documentation: None,
+        homepage: None,
+        urls: vec![],
+        readme: None,
+        license: None,
+    };
+    
+    // Test 1: Convert without ABI inlining (default behavior)
+    let full_package_without_abi = FullPackage::from(db_full_package.clone());
+    assert!(full_package_without_abi.abi_ipfs_url.is_some());
+    assert!(full_package_without_abi.abi.is_none());
+    
+    // Test 2: Simulate ABI inlining process
+    let mock_client = TestMockPinataClient;
+    let mut full_package_with_abi = FullPackage::from(db_full_package.clone());
+    
+    // Simulate the inline_abi=true logic from the endpoint
+    if let Some(abi_hash) = db_full_package.abi_ipfs_hash {
+        match mock_client.fetch_ipfs_content(&abi_hash).await {
+            Ok(abi_content) => {
+                if let Ok(abi_json) = serde_json::from_slice::<serde_json::Value>(&abi_content) {
+                    full_package_with_abi.abi = Some(abi_json);
+                }
+            }
+            Err(_) => {
+                // Should not happen in this test
+                panic!("Mock client should not fail");
+            }
+        }
+    }
+    
+    // Should have both URL and inline content
+    assert!(full_package_with_abi.abi_ipfs_url.is_some());
+    assert!(full_package_with_abi.abi.is_some());
+    
+    // Verify the mock ABI content is correctly fetched and included
+    let abi = full_package_with_abi.abi.as_ref().unwrap();
+    assert!(abi.get("types").is_some());
+    assert!(abi.get("functions").is_some());
+    
+    let functions = abi.get("functions").unwrap().as_array().unwrap();
+    assert_eq!(functions.len(), 1);
+    assert_eq!(functions[0].get("name").unwrap().as_str().unwrap(), "test_function");
+    
+    // Test 3: Verify serialization works correctly
+    let json_with_abi = serde_json::to_value(&full_package_with_abi).unwrap();
+    assert!(json_with_abi.get("abiIpfsUrl").is_some());
+    assert!(json_with_abi.get("abi").is_some());
+    
+    let serialized_abi = json_with_abi.get("abi").unwrap();
+    assert!(serialized_abi.get("types").is_some());
+    assert!(serialized_abi.get("functions").is_some());
+}
+
+#[test]
+#[serial]
+fn test_full_package_abi_field_serialization() {
+    use forc_pub::api::search::FullPackage;
+    use forc_pub::models::PackagePreview;
+    
+    let package_preview_1 = PackagePreview {
+        name: "test-package".to_string(),
+        version: "0.1.0".to_string(),
+        description: Some("Test description".to_string()),
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+    
+    let package_preview_2 = PackagePreview {
+        name: "test-package".to_string(),
+        version: "0.1.0".to_string(),
+        description: Some("Test description".to_string()),
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+    
+    // Test without ABI field
+    let full_package_without_abi = FullPackage {
+        package_preview: package_preview_1,
+        bytecode_identifier: None,
+        forc_version: "0.68.0".to_string(),
+        source_code_ipfs_url: "https://example.com/source".to_string(),
+        abi_ipfs_url: Some("https://example.com/abi".to_string()),
+        abi: None,
+        repository: None,
+        documentation: None,
+        homepage: None,
+        urls: vec![],
+        readme: None,
+        license: None,
+    };
+    
+    let json_without_abi = serde_json::to_value(&full_package_without_abi).unwrap();
+    assert!(json_without_abi.get("abi").is_none());
+    assert!(json_without_abi.get("abiIpfsUrl").is_some());
+    
+    // Test with ABI field
+    let mock_abi = serde_json::json!({
+        "abi": "mock",
+        "types": []
+    });
+    
+    let full_package_with_abi = FullPackage {
+        package_preview: package_preview_2,
+        bytecode_identifier: None,
+        forc_version: "0.68.0".to_string(),
+        source_code_ipfs_url: "https://example.com/source".to_string(),
+        abi_ipfs_url: Some("https://example.com/abi".to_string()),
+        abi: Some(mock_abi.clone()),
+        repository: None,
+        documentation: None,
+        homepage: None,
+        urls: vec![],
+        readme: None,
+        license: None,
+    };
+    
+    let json_with_abi = serde_json::to_value(&full_package_with_abi).unwrap();
+    assert!(json_with_abi.get("abi").is_some());
+    assert!(json_with_abi.get("abiIpfsUrl").is_some());
+    assert_eq!(json_with_abi.get("abi"), Some(&mock_abi));
+}
+
+#[test]
+#[serial]
+fn test_full_package_conversion_maintains_abi_none() {
+    use forc_pub::api::search::FullPackage;
+    use forc_pub::models;
+    use std::env;
+    
+    // Set required environment variable for the test
+    env::set_var("PINATA_URL", "https://test-pinata.com");
+    
+    let db_full_package = models::FullPackage {
+        name: "test".to_string(),
+        version: "0.1.0".to_string(),
+        description: Some("test".to_string()),
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        bytecode_identifier: None,
+        forc_version: "0.68.0".to_string(),
+        source_code_ipfs_hash: "source123".to_string(),
+        abi_ipfs_hash: Some("abi123".to_string()),
+        repository: None,
+        documentation: None,
+        homepage: None,
+        urls: vec![],
+        readme: None,
+        license: None,
+    };
+    
+    let api_full_package = FullPackage::from(db_full_package);
+    
+    // Should have abi_ipfs_url but abi should be None by default
+    assert!(api_full_package.abi_ipfs_url.is_some());
+    assert!(api_full_package.abi.is_none());
+}


### PR DESCRIPTION
This pull request introduces functionality to inline ABI data when requested via the API. It includes changes to the `FullPackage` structure, the addition of a new method to fetch ABI data from IPFS, and corresponding updates to the API endpoint and tests. The most important changes are grouped below.

### ABI Inlining Functionality

* **Added `abi` Field to `FullPackage`**: Introduced an optional `abi` field to the `FullPackage` struct to store inline ABI data when requested. The field is conditionally serialized to avoid unnecessary data in the response. (`src/api/search.rs`, [src/api/search.rsR29-R32](diffhunk://#diff-dbc67644569c7ca2fde96a4c5d2895402b446ef7a181396e337addcf0995574aR29-R32))
* **Updated API Endpoint**: Modified the `package` endpoint to include an `inline_abi` query parameter. When set to true, the endpoint fetches and includes ABI data from IPFS in the response. (`src/main.rs`, [src/main.rsL291-R321](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL291-R321))

### IPFS Fetching Enhancements

* **New Method in `PinataClient`**: Added a `fetch_ipfs_content` method to the `PinataClient` trait and its implementations. This method retrieves content from IPFS using a provided hash. (`src/file_uploader/pinata.rs`, [[1]](diffhunk://#diff-cecd1ce54e71f48bda61808ab722146160c639dc0c439cb37238e41d37b50a55R14-R17) [[2]](diffhunk://#diff-cecd1ce54e71f48bda61808ab722146160c639dc0c439cb37238e41d37b50a55R54-R76) [[3]](diffhunk://#diff-cecd1ce54e71f48bda61808ab722146160c639dc0c439cb37238e41d37b50a55R102-R105)

### Testing Improvements

* **Integration Tests for ABI Inlining**: Added tests to verify the behavior of ABI inlining, including scenarios with and without ABI data, and ensured proper serialization of the `FullPackage` struct. (`tests/db_integration.rs`, [tests/db_integration.rsR424-R624](diffhunk://#diff-63003116e8f9cb61d4067a7396fbea68ffaba85d1734dd92f12704a16d99fe66R424-R624))
* **Mock Client for Testing**: Extended the mock `PinataClient` to simulate fetching ABI data, enabling thorough testing of the inlining functionality. (`src/file_uploader/mod.rs`, [src/file_uploader/mod.rsR83-R85](diffhunk://#diff-e270253e7bde613308e31af2288640be3821a830ce0aa399805b23ad207385dcR83-R85))