### PR TITLE
Add docs.forc.pub host rewrites

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -39,6 +39,30 @@ const nextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: '/',
+        has: [
+          {
+            type: 'host',
+            value: 'docs.forc.pub',
+          },
+        ],
+        destination: '/docs',
+      },
+      {
+        source: '/:path((?!docs/|_next/|api/|favicon\.ico|robots\.txt|sitemap\.xml).*)',
+        has: [
+          {
+            type: 'host',
+            value: 'docs.forc.pub',
+          },
+        ],
+        destination: '/docs/:path',
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### Description:
- route docs.forc.pub requests to the /docs app internally
- leave Next static assets, API routes, and existing /docs paths untouched