### PR TITLE
Route docs.forc.pub via middleware

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const DOCS_HOST = 'docs.forc.pub';
+const BYPASS_PREFIXES = ['/docs', '/_next', '/api', '/favicon.ico', '/robots.txt', '/sitemap.xml'];
+
+export function middleware(request: NextRequest) {
+  const host = request.headers.get('host');
+
+  if (!host || host !== DOCS_HOST) {
+    return NextResponse.next();
+  }
+
+  const { pathname } = request.nextUrl;
+
+  const shouldBypass = BYPASS_PREFIXES.some((prefix) => {
+    if (pathname === prefix) {
+      return true;
+    }
+
+    const normalized = prefix.endsWith('/') ? prefix : `${prefix}/`;
+    return pathname.startsWith(normalized);
+  });
+
+  if (shouldBypass) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = pathname === '/' ? '/docs' : `/docs/${pathname.replace(/^\/+/, '')}`;
+
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: ['/:path*'],
+};

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -39,30 +39,6 @@ const nextConfig = {
       },
     ];
   },
-  async rewrites() {
-    return [
-      {
-        source: '/',
-        has: [
-          {
-            type: 'host',
-            value: 'docs.forc.pub',
-          },
-        ],
-        destination: '/docs',
-      },
-      {
-        source: '/:path((?!docs/|_next/|api/|favicon\.ico|robots\.txt|sitemap\.xml).*)',
-        has: [
-          {
-            type: 'host',
-            value: 'docs.forc.pub',
-          },
-        ],
-        destination: '/docs/:path',
-      },
-    ];
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### Description:

- remove the host-based rewrites from next.config.mjs
- add edge middleware that rewrites docs.forc.pub to /docs while skipping assets/api
- rewrites in the previous PR never triggered in production (Cloudflare proxy skips Vercel host rules), so this middleware runs before routing and guarantees the docs subdomain hits the docs app.