### PR TITLE
Surface documented crates on docs.forc.pub and warm docs loads

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -8,8 +8,17 @@ use url::Url;
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RecentPackagesResponse {
-    pub recently_created: Vec<PackagePreview>,
-    pub recently_updated: Vec<PackagePreview>,
+    pub recently_created: Vec<RecentPackage>,
+    pub recently_updated: Vec<RecentPackage>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentPackage {
+    #[serde(flatten)]
+    pub package: PackagePreview,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docs_ipfs_url: Option<String>,
 }
 
 #[derive(Serialize, Debug)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -218,6 +218,14 @@ pub struct PackagePreview {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(QueryableByName, Debug, Clone)]
+pub struct PackagePreviewWithDocsHash {
+    #[diesel(embed)]
+    pub package: PackagePreview,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub docs_ipfs_hash: Option<String>,
+}
+
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PackagePreviewWithCategories {


### PR DESCRIPTION
- add docs IPFS awareness to `/recent_packages`, letting the docs homepage list packages that actually ship docs
- warm `/docs/<pkg>/<ver>` + `search.js` in the package sidebar so docs open immediately after the user clicks through